### PR TITLE
Fix conflict with Gravity Forms Stripe Add-on

### DIFF
--- a/gravityforms-zero-spam-form-settings.php
+++ b/gravityforms-zero-spam-form-settings.php
@@ -91,9 +91,9 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 	}
 
 	/**
-	 * Include custom tooltip text for the Zero Spam setting in the Form Settings page
+	 * Include custom tooltip text for the Zero Spam setting in the Form Settings page.
 	 *
-	 * @param array $tooltips Key/Value pair of tooltip/tooltip text
+	 * @param array $tooltips Key/Value pair of tooltip/tooltip text.
 	 *
 	 * @return array
 	 */
@@ -105,12 +105,12 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 	}
 
 	/**
-	 * Adds the Zero Spam field to the "Form Options" settings group in GF 2.5+
+	 * Adds the Zero Spam field to the "Form Options" settings group in GF 2.5+.
 	 *
 	 * @see https://docs.gravityforms.com/gform_form_settings_fields/
 	 *
 	 * @param array $fields Form Settings fields.
-	 * @param array $form The current form
+	 * @param array $form   The current form.
 	 *
 	 * @return array
 	 */
@@ -128,7 +128,7 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 	}
 
 	/**
-	 * Register addon global settings
+	 * Register addon global settings.
 	 *
 	 * @return array
 	 */
@@ -341,7 +341,7 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 	 *
 	 * @since 1.4
 	 *
-	 * @param int $entry_id The entry ID.
+	 * @param int    $entry_id       The entry ID.
 	 * @param string $property_value The new status.
 	 *
 	 * @return void
@@ -360,8 +360,8 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 	 *
 	 * @since 1.4
 	 *
-	 * @param array $entry
-	 * @param array $form
+	 * @param array $entry The entry object.
+	 * @param array $form  The form object.
 	 *
 	 * @return void
 	 */
@@ -612,7 +612,7 @@ class GF_Zero_Spam_AddOn extends GFAddOn {
 	/**
 	 * Add cron job for spam reporting.
 	 *
-	 * @param string $frequency
+	 * @param string $frequency The frequency of the cron job.
 	 *
 	 * @return string
 	 */

--- a/gravityforms-zero-spam.php
+++ b/gravityforms-zero-spam.php
@@ -49,7 +49,7 @@ class GF_Zero_Spam {
 	}
 
 	public function __construct() {
-		add_action( 'gform_register_init_scripts', array( $this, 'add_key_field' ), 9999 );
+		add_action( 'gform_register_init_scripts', array( $this, 'add_key_field' ), 1 );
 		add_filter( 'gform_entry_is_spam', array( $this, 'check_key_field' ), 10, 3 );
 		add_filter( 'gform_incomplete_submission_pre_save', array( $this, 'add_zero_spam_key_to_entry' ), 10, 3 );
 	}
@@ -66,10 +66,14 @@ class GF_Zero_Spam {
 	public function add_zero_spam_key_to_entry( $submission_json, $resume_token, $form ) {
 		$submission = json_decode( $submission_json, true );
 
-		if ( ! isset( $submission['partial_entry']['gf_zero_spam_key'] ) ) {
-			$spam_key = rgpost( 'gf_zero_spam_key' );
+		// If it's not a valid JSON, just return the original submission.
+		if ( ! is_array( $submission ) ) {
+			return $submission_json;
+		}
 
-			$submission['partial_entry']['gf_zero_spam_key'] = $spam_key;
+		// If the zero spam key is already set, just return the original submission.
+		if ( isset( $submission['partial_entry'] ) && ! isset( $submission['partial_entry']['gf_zero_spam_key'] ) ) {
+			$submission['partial_entry']['gf_zero_spam_key'] = rgpost( 'gf_zero_spam_key' );;
 		}
 
 		return json_encode( $submission );

--- a/gravityforms-zero-spam.php
+++ b/gravityforms-zero-spam.php
@@ -65,15 +65,13 @@ class GF_Zero_Spam {
 	public function add_zero_spam_key_to_entry( $submission_json, $resume_token, $form ) {
 		$submission = json_decode( $submission_json, true );
 
-		// If it's not a valid JSON, just return the original submission.
-		if ( ! is_array( $submission ) ) {
+		// If it's not a valid JSON, partial entry is not set or the zero spam key is already set, return the original submission.
+		if ( ! is_array( $submission ) || ! isset( $submission['partial_entry'] ) || isset( $submission['partial_entry']['gf_zero_spam_key'] )) {
 			return $submission_json;
 		}
 
-		// If the zero spam key is already set, just return the original submission.
-		if ( isset( $submission['partial_entry'] ) && ! isset( $submission['partial_entry']['gf_zero_spam_key'] ) ) {
-			$submission['partial_entry']['gf_zero_spam_key'] = rgpost( 'gf_zero_spam_key' );;
-		}
+		// Add the zero spam key to the partial entry if it's available in the POST data.
+		$submission['partial_entry']['gf_zero_spam_key'] = rgpost( 'gf_zero_spam_key' );;
 
 		return json_encode( $submission );
 	}

--- a/gravityforms-zero-spam.php
+++ b/gravityforms-zero-spam.php
@@ -10,26 +10,25 @@
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-// my mother always said to use things as they're intended or not at all
+// my mother always said to use things as they're intended or not at all.
 if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
 define( 'GF_ZERO_SPAM_BASENAME', plugin_basename( __FILE__ ) );
 
-// clean up after ourselves
+// clean up after ourselves.
 register_deactivation_hook( __FILE__, array( 'GF_Zero_Spam', 'deactivate' ) );
 
-// Fire it up
+// Fire it up.
 add_action( 'gform_loaded', array( 'GF_Zero_Spam', 'gform_loaded' ) );
 
 class GF_Zero_Spam {
 
 	/**
-	 * Instantiate the plugin on Gravity Forms loading
+	 * Instantiate the plugin on Gravity Forms loading.
 	 */
 	public static function gform_loaded() {
-
 		include_once plugin_dir_path( __FILE__ ) . 'gravityforms-zero-spam-form-settings.php';
 
 		new self;
@@ -80,12 +79,11 @@ class GF_Zero_Spam {
 	}
 
 	/**
-	 * Retrieves the zero spam key (generating if needed)
+	 * Retrieves the zero spam key (generating if needed).
 	 *
 	 * @return false|mixed|void
 	 */
 	public function get_key() {
-
 		$key = get_option( 'gf_zero_spam_key' );
 
 		if ( ! $key ) {
@@ -97,19 +95,20 @@ class GF_Zero_Spam {
 	}
 
 	/**
-	 * Injects the hidden field and key into the form at submission
+	 * Injects the hidden field and key into the form at submission.
 	 *
 	 * @uses GFFormDisplay::add_init_script() to inject the code into the `gform_post_render` jQuery hook.
 	 *
-	 * @param array $form The Form Object
+	 * @param array $form The Form Object.
 	 *
 	 * @return void
 	 */
 	public function add_key_field( $form ) {
-
 		/**
 		 * Allows the zero spam key field to be disabled by returning false.
+		 *
 		 * @since 1.4
+		 *
 		 * @param bool $add_key_field Whether to add the key field to the form. Default true.
 		 */
 		$add_key_field = apply_filters( 'gf_zero_spam_add_key_field', true );
@@ -136,11 +135,11 @@ EOD;
 	}
 
 	/**
-	 * Checks for our zero spam key during validation
+	 * Checks for our zero spam key during validation.
 	 *
-	 * @param bool $is_spam Indicates if the submission has been flagged as spam.
-	 * @param array $form The form currently being processed.
-	 * @param array $entry The entry currently being processed.
+	 * @param bool  $is_spam Indicates if the submission has been flagged as spam.
+	 * @param array $form    The form currently being processed.
+	 * @param array $entry   The entry currently being processed.
 	 *
 	 * @return bool True: it's spam; False: it's not spam!
 	 */
@@ -153,9 +152,9 @@ EOD;
 		 *
 		 * @since 1.2
 		 *
-		 * @param bool $should_check_key_field Whether the Zero Spam plugin should check for the existence and validity of the key field. Default: true.
-		 * @param array $form The form currently being processed.
-		 * @param array $entry The entry currently being processed.
+		 * @param bool  $should_check_key_field Whether the Zero Spam plugin should check for the existence and validity of the key field. Default: true.
+		 * @param array $form                   The form currently being processed.
+		 * @param array $entry                  The entry currently being processed.
 		 */
 		$should_check_key_field = gf_apply_filters( 'gf_zero_spam_check_key_field', rgar( $form, 'id' ), $should_check_key_field, $form, $entry );
 
@@ -168,12 +167,12 @@ EOD;
 			return $is_spam;
 		}
 
-	    // This was not submitted using a web form; created using API
+	    // This was not submitted using a web form; created using API.
 		if ( ! $supports_context && ! did_action( 'gform_pre_submission' ) ) {
 			return $is_spam;
 		}
 
-		// Created using REST API or GFAPI
+		// Created using REST API or GFAPI.
 		if ( isset( $entry['user_agent'] ) && 'API' === $entry['user_agent'] ) {
 			return $is_spam;
 		}
@@ -195,7 +194,6 @@ EOD;
 	 * @param array $entry The entry data.
 	 */
 	public function add_entry_note( $entry ) {
-
 		if ( 'spam' !== rgar( $entry, 'status' ) ) {
 			return;
 		}
@@ -206,5 +204,4 @@ EOD;
 
 		GFAPI::add_note( $entry['id'], 0, 'Zero Spam', __( 'This entry has been marked as spam.', 'gf-zero-spam' ), 'gf-zero-spam', 'success' );
 	}
-
 }


### PR DESCRIPTION
**Issue**

With the recent update to Gravity Forms Stripe add-on 5.1.0, once enabling the Alternate Payment Methods (for Apple/Google Pay, etc). Entries were getting flagged as spam

**Expected Behaviour**

Entries should not marked as spam. 

Fixes #22 