### PR TITLE
Use gform/submission/pre_submission to add input

### DIFF
--- a/gravityforms-zero-spam.php
+++ b/gravityforms-zero-spam.php
@@ -136,19 +136,34 @@ class GF_Zero_Spam {
 
 		$form_id = (int) $form['id'];
 
-		$autocomplete = RGFormsModel::is_html5_enabled() ? ".attr( 'autocomplete', 'new-password' )\n\t\t" : '';
+		if ( version_compare( GFForms::$version, '2.9.0', '>=' ) ) {
+			$script = <<<EOD
+				gform.utils.addAsyncFilter('gform/submission/pre_submission', async (data) => {
+				    const input = document.createElement('input');
+				    input.type = 'hidden';
+				    input.name = 'gf_zero_spam_key';
+				    input.value = '{$spam_key}';
+				    input.setAttribute('autocomplete', 'new-password');
+				    data.form.appendChild(input);
+				
+				    return data;
+				});
+				EOD;
+		} else {
+			$autocomplete = RGFormsModel::is_html5_enabled() ? ".attr( 'autocomplete', 'new-password' )\n\t\t" : '';
 
-		$script = <<<EOD
-jQuery( "#gform_{$form_id}" ).on( 'submit', function( event ) {
-	jQuery( '<input>' )
-		.attr( 'type', 'hidden' )
-		.attr( 'name', 'gf_zero_spam_key' )
-		.attr( 'value', '{$spam_key}' )
-		$autocomplete.appendTo( jQuery( this ) );
-} );
-EOD;
+			$script = <<<EOD
+				jQuery( "#gform_{$form_id}" ).on( 'submit', function( event ) {
+					jQuery( '<input>' )
+						.attr( 'type', 'hidden' )
+						.attr( 'name', 'gf_zero_spam_key' )
+						.attr( 'value', '{$spam_key}' )
+						$autocomplete.appendTo( jQuery( this ) );
+				} );
+				EOD;
+		}
 
-		GFFormDisplay::add_init_script( $form['id'], 'gf-zero-spam', GFFormDisplay::ON_PAGE_RENDER, $script );
+		GFFormDisplay::add_init_script( $form_id, 'gf-zero-spam', GFFormDisplay::ON_PAGE_RENDER, $script );
 	}
 
 	/**


### PR DESCRIPTION
Gravity Forms 2.9 includes a new form submission handler, which includes new filters and events. This makes use of the new gform/submission/pre_submission filter to add the gf_zero_spam_key input, with a fallback to the previous approach for older versions.

It also resolves #36